### PR TITLE
Update webpack.common.js

### DIFF
--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -42,6 +42,10 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, '..', './build'),
     filename: 'bundle.js',
+    publicPath: '/',
+  },
+  devServer: {
+    historyApiFallback: true,
   },
   plugins: [
     new HtmlWebpackPlugin({


### PR DESCRIPTION
add devServer config and add public path to avoid "cannot /GET" error for React Router Dom V6